### PR TITLE
update parse_server_info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@
 lmutil.exe
 venv/
 .idea/
-app/config.py

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 lmutil.exe
 venv/
 .idea/
+app/config.py

--- a/app/config.py
+++ b/app/config.py
@@ -15,7 +15,7 @@ class BaseConfig(object):
     LOG_BACKUPS = 0
     SECRET_KEY = 'houdini'
     # use sqlite by default
-    SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL', 'sqlite:///app.db')
+    SQLALCHEMY_DATABASE_URI = 'sqlite:///app.db'
 
 
 class DevelopmentConfig(BaseConfig):

--- a/app/config.py
+++ b/app/config.py
@@ -15,7 +15,7 @@ class BaseConfig(object):
     LOG_BACKUPS = 0
     SECRET_KEY = 'houdini'
     # use sqlite by default
-    SQLALCHEMY_DATABASE_URI = 'sqlite:///app.db'
+    SQLALCHEMY_DATABASE_URI = os.getenv('DATABASE_URL', 'sqlite:///app.db')
 
 
 class DevelopmentConfig(BaseConfig):

--- a/app/read_licenses.py
+++ b/app/read_licenses.py
@@ -45,7 +45,16 @@ def split_license_data(text):
 
 
 def parse_server_info(lines):
-    return parse("{:^}:\n{}: LICENSE SERVER {:w} (MASTER) V11.16.2{:^}", lines, case_sensitive=False)
+    """
+    Returns an iterable parse.Result object. The parsed word({:w}) should indicate the server status (UP/DOWN). 
+    If the parsing fails (returns None) the parsing in this function may need to be adjusted.
+    """
+    p = parse("{:^}:\n{}: LICENSE SERVER {:w} (MASTER) V{}\n{:^}", lines, case_sensitive=False)
+    if p == None:
+        p = parse("{:^}:\n{}: LICENSE SERVER {:w} V{}\n{:^}", lines, case_sensitive=False)
+    if p == None:
+        logger.info('Server status parse failed. Check read_licenses.parse_server_info against lmutil.exe output.')
+    return p
 
 
 def parse_product_info(lines):

--- a/tests/base.py
+++ b/tests/base.py
@@ -16,6 +16,9 @@ class BaseTestCase(TestCase):
         with open(os.path.join(dir_path, 'data', 'prod-license.txt')) as data:
             self.prod_server_data = data.read()
 
+        with open(os.path.join(dir_path, 'data', 'prod-license-v2.txt')) as data:
+            self.prod_server_data_v2 = data.read()
+
         with open(os.path.join(dir_path, 'data', 'backup-license.txt')) as data:
             self.backup_server_data = data.read()
 

--- a/tests/data/prod-license-v2.txt
+++ b/tests/data/prod-license-v2.txt
@@ -1,0 +1,92 @@
+lmutil - Copyright (c) 1989-2021 Flexera. All Rights Reserved.
+Flexible License Manager status on Mon 9/26/2022 11:59
+ 
+[Detecting lmgrd processes...]
+License server status: 27000@stgarcgis103
+    License file(s) on stgarcgis103: C:\Program Files\ArcGIS\LicenseManager\bin\service.txt:
+ 
+stgarcgis103: license server UP v11.18.2
+ 
+Vendor daemon status (on STGARCGIS103):
+ 
+    ARCGIS: UP v11.18.2
+Feature usage info:
+ 
+Users of ACT:  (Total of 1 license issued;  Total of 0 licenses in use)
+ 
+Users of 3DAnalystP:  (Total of 4 licenses issued;  Total of 0 licenses in use)
+ 
+Users of ARC/INFO:  (Total of 3 licenses issued;  Total of 0 licenses in use)
+ 
+Users of ArcStorm:  (Total of 3 licenses issued;  Total of 0 licenses in use)
+ 
+Users of ArcStormEnable:  (Total of 3 licenses issued;  Total of 0 licenses in use)
+ 
+Users of dataInteropP:  (Total of 1 license issued;  Total of 1 license in use)
+ 
+  "dataInteropP" v10.1, vendor: ARCGIS, expiry: permanent(no expiration date)
+  floating license
+ 
+    felicia GC-04-026P DESKTOP-ABEPPIC (v10.1) (stgarcgis103/27000 902), start Mon 9/26 10:50
+ 
+Users of desktopAdvP:  (Total of 3 licenses issued;  Total of 2 licenses in use)
+ 
+  "desktopAdvP" v10.1, vendor: ARCGIS, expiry: permanent(no expiration date)
+  floating license
+ 
+    felicia GC-04-026P DESKTOP-ABEPPIC (v10.1) (stgarcgis103/27000 802), start Mon 9/26 10:49
+    jimmy devinfosandbox 10VMGC126 (v10.1) (stgarcgis103/27000 502), start Mon 9/26 10:56
+ 
+Users of desktopBasicP:  (Total of 15 licenses issued;  Total of 0 licenses in use)
+ 
+Users of desktopStdP:  (Total of 2 licenses issued;  Total of 0 licenses in use)
+ 
+Users of Editor:  (Total of 2 licenses issued;  Total of 0 licenses in use)
+ 
+Users of geostatAnalystP:  (Total of 5 licenses issued;  Total of 1 license in use)
+ 
+  "geostatAnalystP" v10.1, vendor: ARCGIS, expiry: permanent(no expiration date)
+  floating license
+ 
+    felicia GC-04-026P DESKTOP-ABEPPIC (v10.1) (stgarcgis103/27000 402), start Mon 9/26 10:50
+ 
+Users of GeoStats:  (Total of 5 licenses issued;  Total of 0 licenses in use)
+ 
+Users of Grid:  (Total of 6 licenses issued;  Total of 0 licenses in use)
+ 
+Users of Interop:  (Total of 1 license issued;  Total of 0 licenses in use)
+ 
+Users of MrSID:  (Total of 3 licenses issued;  Total of 0 licenses in use)
+ 
+Users of Network:  (Total of 4 licenses issued;  Total of 0 licenses in use)
+ 
+Users of networkAnalystP:  (Total of 4 licenses issued;  Total of 1 license in use)
+ 
+  "networkAnalystP" v10.1, vendor: ARCGIS, expiry: permanent(no expiration date)
+  floating license
+ 
+    felicia GC-04-026P DESKTOP-ABEPPIC (v10.1) (stgarcgis103/27000 302), start Mon 9/26 10:50
+ 
+Users of Plotting:  (Total of 3 licenses issued;  Total of 0 licenses in use)
+ 
+Users of Publisher:  (Total of 5 licenses issued;  Total of 0 licenses in use)
+ 
+Users of spatialAnalystP:  (Total of 5 licenses issued;  Total of 1 license in use)
+ 
+  "spatialAnalystP" v10.1, vendor: ARCGIS, expiry: permanent(no expiration date)
+  floating license
+ 
+    felicia GC-04-026P DESKTOP-ABEPPIC (v10.1) (stgarcgis103/27000 602), start Mon 9/26 10:50
+ 
+Users of TIFFLZW:  (Total of 3 licenses issued;  Total of 0 licenses in use)
+ 
+Users of TIN:  (Total of 4 licenses issued;  Total of 0 licenses in use)
+ 
+Users of Tracking:  (Total of 5 licenses issued;  Total of 0 licenses in use)
+ 
+Users of Viewer:  (Total of 15 licenses issued;  Total of 1 license in use)
+ 
+  "Viewer" v10.1, vendor: ARCGIS, expiry: permanent(no expiration date)
+  floating license
+ 
+    jimmy 10VMGC126 x(CIt+VSq2&Jr,?C|jFymF5}z`/ (v10.1) (stgarcgis103/27000 702), start Mon 9/26 10:08

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -8,6 +8,9 @@ class TestFunctions(BaseTestCase):
     def test_parse_server_info(self):
         result = parse_server_info(self.prod_server_data)
         self.assertEqual(result[2], 'UP')
+        
+        result = parse_server_info(self.prod_server_data_v2)
+        self.assertEqual(result[2], 'UP')
 
         result = parse_server_info(self.backup_server_data)
         self.assertEqual(result[2], 'UP')
@@ -18,6 +21,9 @@ class TestFunctions(BaseTestCase):
     def test_split_license_data(self):
         result = split_license_data(self.prod_server_data)
         self.assertEqual(len(result), 21)
+
+        result = split_license_data(self.prod_server_data_v2)
+        self.assertEqual(len(result), 25)
 
         result = split_license_data(self.backup_server_data)
         self.assertEqual(len(result), 21)


### PR DESCRIPTION
Removed license manager version number hardcoding from read_licenses.parse_server_info.

Wrote a slightly more robust parse_server_info function which allows for different license manager versions. The previous code would cause all read status to be 'DOWN' if the license manager version was not 11.16.2.

Also "(MASTER)" may or may not be present in the lmutil output (it is not present in the environment I am running). 

Passes the current unit test.